### PR TITLE
Add Config and concatenate altNames values

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,17 @@ A node module to automatically run https on localhost
     })
     
 The first time this is run it will install a root certificate and localhost certificare in the folder `~/.https-local`. On MacOS the root certificate will be imported into your keychain and you will be prompted for your password. On other operating systems you need to install the `root-cert.pem` manually for your system.
+
+### Optional config parameters
+Allows to extend the altNames values
+```
+require('https-local').options({
+  altNames: [{
+      type: 2,
+      value: '192.168.1.1'
+    },{
+      type: 7,
+      ip: '192.168.1.1'
+    }]
+})
+```

--- a/index.js
+++ b/index.js
@@ -92,12 +92,10 @@ function install (config) {
     clientAuth: true
   }, {
     name: 'subjectAltName',
-    altNames: [
-      {
-        type: 2,
-        value: 'localhost'
-      }
-    ]
+    altNames: [{
+      type: 2,
+      value: 'localhost'
+    }]
   }]
   if (config.altNames) setExtensions[3].altNames.concat(config.altNames)
   localhostCert.setExtensions(setExtensions)

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function install (config) {
   var validity = {}
   validity.notBefore = new Date()
   validity.notAfter = new Date()
-  validity.notAfter.setFullYear(validity.notBefore.getFullYear() + 25)
+  validity.notAfter.setFullYear(validity.notBefore.getFullYear() + 1)
 
   // CREATE ROOT KEY
   var rootKey = forge.pki.rsa.generateKeyPair(2048)

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function addTrustedRootCert () {
   }
 }
 
-function install () {
+function install (config) {
   mkdirp(location)
 
   var validity = {}
@@ -78,7 +78,7 @@ function install () {
   localhostCert.validity = validity
   localhostCert.setSubject([localhostCommonName])
   localhostCert.setIssuer([rootCommonName])
-  localhostCert.setExtensions([{
+  let setExtensions = [{
     name: 'keyUsage',
     critical: true,
     digitalSignature: true,
@@ -92,11 +92,15 @@ function install () {
     clientAuth: true
   }, {
     name: 'subjectAltName',
-    altNames: [{
-      type: 2,
-      value: 'localhost'
-    }]
-  }])
+    altNames: [
+      {
+        type: 2,
+        value: 'localhost'
+      }
+    ]
+  }]
+  if (config.altNames) setExtensions[3].altNames.concat(config.altNames)
+  localhostCert.setExtensions(setExtensions)
   localhostCert.sign(rootKey.privateKey, forge.md.sha256.create())
   var localhostCertPem = forge.pki.certificateToPem(localhostCert)
 
@@ -110,9 +114,9 @@ function install () {
   console.log(location + '/root-cert.pem')
 }
 
-function options () {
+function options (config) {
   if (!isInstalled()) {
-    install()
+    install(config)
     addTrustedRootCert()
   }
   return {

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ function install (config) {
       value: 'localhost'
     }]
   }]
-  if (config.altNames) setExtensions[3].altNames.concat(config.altNames)
+  if (config.altNames) setExtensions[3].altNames = setExtensions[3].altNames.concat(config.altNames)
   localhostCert.setExtensions(setExtensions)
   localhostCert.sign(rootKey.privateKey, forge.md.sha256.create())
   var localhostCertPem = forge.pki.certificateToPem(localhostCert)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "https-local",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "https-local",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "https-local",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A Certificate Authority for Localhost",
   "main": "index.js",
   "author": "Ben McCurdy <bpmccurdy@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "https-local",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A Certificate Authority for Localhost",
   "main": "index.js",
   "author": "Ben McCurdy <bpmccurdy@gmail.com>",


### PR DESCRIPTION
In case you need to add IPs other than localhost
```
require('https-local').options({
      altNames: [{
          type: 2,
          value: '192.168.1.1'
        },{
          type: 7,
          ip: '192.168.1.1'
        }]
    })
```